### PR TITLE
corrected the order of arguments to function

### DIFF
--- a/jsp-microform/src/main/java/com/cybersource/example/FlexKeyProvider.java
+++ b/jsp-microform/src/main/java/com/cybersource/example/FlexKeyProvider.java
@@ -52,7 +52,7 @@ public class FlexKeyProvider {
                 
             KeyGenerationApi keyGenerationApi = new KeyGenerationApi(apiClient);
 
-            FlexV1KeysPost200Response response = keyGenerationApi.generatePublicKey(request, "JWT");
+            FlexV1KeysPost200Response response = keyGenerationApi.generatePublicKey("JWT", request);
             System.out.println("Response :" +response);
 
             String responseCode = apiClient.responseCode;


### PR DESCRIPTION
The function accepts String followed by Request object:
generatePublicKey(String format, GeneratePublicKeyRequest generatePublicKeyRequest)

The arguments passed to the function need to be swapped in order to maintain consistency and avoid build failure.